### PR TITLE
[주찬] Fix : jwtutil secret key, SecurityConfig 오타 및 로직 변경

### DIFF
--- a/OAuth2JWT/src/main/java/com/practice/oauth2jwt/config/SecurityConfig.java
+++ b/OAuth2JWT/src/main/java/com/practice/oauth2jwt/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -73,7 +74,7 @@ public class SecurityConfig {
 
         //JWTFilter 추가
         http
-                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAfter(new JWTFilter(jwtUtil), OAuth2LoginAuthenticationFilter.class);
 
         //oauth2
         http

--- a/OAuth2JWT/src/main/java/com/practice/oauth2jwt/jwt/JWTFilter.java
+++ b/OAuth2JWT/src/main/java/com/practice/oauth2jwt/jwt/JWTFilter.java
@@ -24,6 +24,19 @@ public class JWTFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestUri = request.getRequestURI();
+
+        if (requestUri.matches("^\\/login(?:\\/.*)?$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if (requestUri.matches("^\\/oauth2(?:\\/.*)?$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         //cookie들을 불러온 뒤 Authorization Key에 담긴 쿠키를 찾음
         String authorization =null;
         Cookie[] cookies = request.getCookies();

--- a/OAuth2JWT/src/main/java/com/practice/oauth2jwt/jwt/JWTUtil.java
+++ b/OAuth2JWT/src/main/java/com/practice/oauth2jwt/jwt/JWTUtil.java
@@ -14,7 +14,7 @@ public class JWTUtil {
 
     private SecretKey secretKey;
 
-    public JWTUtil(@Value("${spring.jwt.secret")String secret){
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret){
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 

--- a/oauth2_jwt_practice/src/LoginPage.jsx
+++ b/oauth2_jwt_practice/src/LoginPage.jsx
@@ -1,0 +1,13 @@
+const LoginPage= () =>{
+    const onNaverLogin = () => {
+        window.location.href = "http://localhost:8080/oauth2/authorization/naver"
+    }
+
+    return(
+        <>
+        <h1>Login</h1>
+        <button onClick={onNaverLogin}> naver login</button>
+        </>
+    );
+};
+export default LoginPage


### PR DESCRIPTION
JWTUtil 에서 secretkey에서 '}' 가 빠져있어서 jwt 생성 시 secretkey가 제대로 주입되지 않아 오류가 생기는 현상을 수정하였습니다.
securityconfig에서 jwtfilter가 먼저 주입되어 무한 로그인이 시도 될 수도 있는 현상을 수정하였습니다.
그리고 혹시 몰라 jwtfilter에서 특정 url로 들어오는 경로는 jwtfilter를 거치지 않고 지나갈수 있게 수정하였습니다.

jwt 생성 확인을 위해 vite로 react 프로젝트를 생성하였습니다.
react 프로젝트가 vite로 형성하여 5173인데 백에서 3000으로 설정하였기 때문에 vite.config에서 server를 3000번으로 가게 변경하였습니다.

jwt 토큰 생성되는 것을 확인하였습니다. 